### PR TITLE
Update sp_LogHunter.sql

### DIFF
--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -183,7 +183,7 @@ BEGIN
         WHERE m.language_id = @language_id
     )
     BEGIN
-       RAISERROR(N'%is not not a valid language_id in sys.messages.', 11, 1, @language_id) WITH NOWAIT;
+       RAISERROR(N'%i is not not a valid language_id in sys.messages.', 11, 1, @language_id) WITH NOWAIT;
        RETURN;
     END;
     


### PR DESCRIPTION
Hello Erik!
   RAISERROR(N'%is not not a valid language_id in sys.messages.', 11, 1, @language_id) WITH NOWAIT;

%i is for integer, in that way you print "103333s not not a valid language_id in sys.messages."